### PR TITLE
Fix wrong branch on push

### DIFF
--- a/.github/workflows/staticanalysis.yml
+++ b/.github/workflows/staticanalysis.yml
@@ -3,7 +3,7 @@ name: Static Analysis
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests and Coverage
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
## Summary
<!-- What does this PR change? -->
Changes the branch on push to `master` instead of `main`.

## Related Issues
<!-- Link task / user story -->
Closes: N/A

## Changes Made
- Change from main to master since that is our default branch that we want the workflow to run on every push.

## Testing
<!-- Required -->
- [x] Manual testing performed (describe briefly)
- [x] Unit tests added or updated (if applicable)
- [x] All tests pass locally / in CI

## Checklist (Author & Reviewer)
- [x] Code follows project conventions
- [x] The change was run locally and works as expected
- [x] Acceptance criteria met
- [x] No breaking changes
